### PR TITLE
Enable "canonical" when creating JSON.

### DIFF
--- a/bin/mkjson
+++ b/bin/mkjson
@@ -22,7 +22,7 @@ while (<$csv>) {
   };
 }
 
-my $json = JSON->new->pretty(1)->encode($data);
+my $json = JSON->new->canonical(1)->pretty(1)->encode($data);
 
 open my $json_fh, '>', $out;
 


### PR DESCRIPTION
This will be slightly slower, but allows for less churn in the generated
file(s).
